### PR TITLE
dockerize-lunar.sh: fix for bad host PATH

### DIFF
--- a/dockerize-lunar.sh
+++ b/dockerize-lunar.sh
@@ -9,7 +9,7 @@ chroot_run() {
   # mount --bind /tmp $TARGET/tmp
   # mount --bind /sys $TARGET/sys
   # mount --bind /run $TARGET/run
-  chroot $TARGET "$@"
+  chroot PATH=/sbin:/bin:/usr/sbin:/usr/bin $TARGET "$@"
   RESULT=$?
   # umount $TARGET/run
   # umount $TARGET/sys
@@ -101,7 +101,7 @@ main() {
   mkdir -p bin boot dev etc home lib mnt media
   mkdir -p proc root sbin srv tmp usr var opt
   mkdir -p sys
-  if [ `arch` == "x86_64" ]; then
+  if [ `uname -m` == "x86_64" ]; then
     ln -sf lib lib64
     ln -sf lib usr/lib64
   fi


### PR DESCRIPTION
I have encountered some systems where /bin and /sbin were not in PATH.

The errors were:
```[...]
Transfering dhcpcd...
Transfering systemd...
Transfering dbus...
chroot: failed to run command ‘lsh’: No such file or directory
chroot: failed to run command ‘lsh’: No such file or directory
chroot: failed to run command ‘lsh’: No such file or directory
chroot: failed to run command ‘ldconfig’: No such file or directory
chroot: failed to run command ‘lvu’: No such file or directory
Creating docker image...
[...]```